### PR TITLE
feat: Implements turnstile captcha for login/signup bot protection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "marked-highlight": "^2.0.1",
         "marked-mangle": "^1.1.7",
         "ng-apexcharts": "^1.12.0",
+        "ngx-turnstile": "^0.2.4",
         "pg": "^8.13.1",
         "primeflex": "^3.3.1",
         "primeicons": "^7.0.0",
@@ -19241,6 +19242,19 @@
         "@angular/core": "^18.0.4",
         "apexcharts": "^3.53.0",
         "rxjs": "^6.5.5 || ^7.4.0"
+      }
+    },
+    "node_modules/ngx-turnstile": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/ngx-turnstile/-/ngx-turnstile-0.2.4.tgz",
+      "integrity": "sha512-aayGBTtMPl7Ez5FY5tSl81PvBooARlnEB2H7MEqbd3/L92U5c+EodTsN3zj4eb88aCOg3ok6K+8IrQ+dmcbdxA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.5.2"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=16.0.0",
+        "@angular/core": ">=16.0.0"
       }
     },
     "node_modules/nice-napi": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "marked-highlight": "^2.0.1",
     "marked-mangle": "^1.1.7",
     "ng-apexcharts": "^1.12.0",
+    "ngx-turnstile": "^0.2.4",
     "pg": "^8.13.1",
     "primeflex": "^3.3.1",
     "primeicons": "^7.0.0",

--- a/src/app/pages/(auth)/login.page.html
+++ b/src/app/pages/(auth)/login.page.html
@@ -113,6 +113,16 @@
                     text="You must agree to the terms and conditions"></p-message>
         </div>
 
+        <!--  Captcha -->
+        <ngx-turnstile
+          *ngIf="turnstileSiteKey"
+          class="text-center mb-4"
+          [siteKey]="turnstileSiteKey"
+          (resolved)="sendCaptchaResponse($event)"
+          theme="auto"
+          [tabIndex]="0"
+        />
+
         <p-button type="submit" [label]="isLogin ? 'Login' : 'Sign Up'" styleClass="w-full"
                   [disabled]="form.invalid || disabled" [loading]="showLoader"></p-button>
       </form>

--- a/src/app/services/environment.service.ts
+++ b/src/app/services/environment.service.ts
@@ -13,6 +13,7 @@ type EnvVar =
 | 'DL_GLITCHTIP_DSN'    // GlitchTip DSN, for error tracking
 | 'DL_PLAUSIBLE_URL'    // URL to Plausible instance, for hit counting
 | 'DL_PLAUSIBLE_SITE'   // Plausible site ID /  URL, for hit counting
+| 'DL_TURNSTILE_KEY'    // Cloudflare public site key for Turnstile captcha
 | 'DL_PG_HOST'          // Postgres host
 | 'DL_PG_PORT'          // Postgres port
 | 'DL_PG_NAME'          // Postgres DB name

--- a/src/app/services/supabase.service.ts
+++ b/src/app/services/supabase.service.ts
@@ -124,20 +124,23 @@ export class SupabaseService {
     return user;
   }
 
-  async signUp(email: string, password: string) {
-    const { data, error } = await this.supabase.auth.signUp({ email, password });
+  async signUp(email: string, password: string, captchaToken?: string) {
+    const { data, error } = await this.supabase.auth.signUp(
+      { email, password, options: { captchaToken } },
+    );
     if (error) throw error;
     return data;
   }
 
-  async signIn(email: string, password: string): Promise<{
+  async signIn(email: string, password: string, captchaToken?: string): Promise<{
     requiresMFA: boolean;
     factors: Factor[];
   }> {
     // First verify credentials and reach AAL1
     const { data, error } = await this.supabase.auth.signInWithPassword({
       email,
-      password
+      password,
+      options: { captchaToken },
     });
     
     if (error) throw error;


### PR DESCRIPTION
This PR implements (optional) captcha protection, using Cloudlare Turnstile. Currently it covers login and sighnup, but it can be easily extended to protect other vectors which a bot may target.


## Usage

### Step 1 - Register
In Cloudflare dashboard, navigate to Turnstile, and create a new site. Add hostnames and copy the site key.

![image](https://github.com/user-attachments/assets/3dc73b9b-ef3b-46ee-8fc8-2e70abf62fe9)

### Step 2 - Enable

In Supabase, navigate to Auth --> Protection --> Captcha, and enable Turnstile, specifying your secret key.

![image](https://github.com/user-attachments/assets/fc890304-79c2-4b77-9cea-b5234a7123ed)

### Step 3 - Use

Finally, set the `DL_TURNSTILE_KEY` environmental variable to your Turnstile public key.

![image](https://github.com/user-attachments/assets/88a80bd7-ef19-4cab-950f-f2108c5d296a)

---


## Tutorial for Future Me

Implementing this with Supabase took me a few minutes to figure out, so I thought I'd document the setup here either for future me, or anyone else trying to do something similar in Angular.

For an example, see the diff in c60d19994b2743ef6958f328033d23b5975946f2


### 1. Install the Turnstile package

```bash
yarn add ngx-turnstile
```

### 2. Add your Site Key

Set your public key (from [Cloudflare](https://developers.cloudflare.com/turnstile/)) as an environment variable.

```bash
DL_TURNSTILE_KEY=your-site-key
```

- In Angular, make sure this is exposed to the browser (e.g. `VITE_` prefix or accessible via your env service)
- Add it to Docker Compose or Vercel’s env vars too

### 3. Drop it into the HTML

Add the widget to your login/signup template:

```html
<ngx-turnstile
  *ngIf="turnstileSiteKey"
  [siteKey]="turnstileSiteKey"
  (resolved)="sendCaptchaResponse($event)"
  theme="auto"
/>
```

### 4. Update your component logic

Import the module and capture the token:

```ts
@ViewChild(NgxTurnstileComponent) turnstile!: NgxTurnstileComponent;
turnstileResponse?: string;

sendCaptchaResponse(token: string | null) {
  this.turnstileResponse = token || undefined;
}
```

Pass the token when logging in or signing up:

```ts
await this.supabaseService.signIn(email, password, this.turnstileResponse);
```

### 5. Update Supabase calls

Make sure your auth service forwards the `captchaToken`:

```ts
signIn(email: string, password: string, captchaToken?: string) {
  return this.supabase.auth.signInWithPassword({
    email,
    password,
    options: { captchaToken }
  });
}
```

Same goes for `signUp`, or anything else u wanna put behind a captcha.


