### PR TITLE
helm: add support for secrets

### DIFF
--- a/helm/templates/app-deployment.yaml
+++ b/helm/templates/app-deployment.yaml
@@ -22,5 +22,12 @@ spec:
           env:
             {{- range $key, $value := .Values.app.env }}
             - name: {{ $key }}
+              {{- if hasKey $.Values.app.secretEnv $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (index $.Values.app.secretEnv $key).name }}
+                  key: {{ (index $.Values.app.secretEnv $key).key }}
+              {{- else }}
               value: {{ $value | quote }}
+              {{- end }}
             {{- end }}

--- a/helm/templates/postgres-deployment.yaml
+++ b/helm/templates/postgres-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,7 +22,21 @@ spec:
             - name: POSTGRES_USER
               value: {{ .Values.postgres.env.POSTGRES_USER | quote }}
             - name: POSTGRES_PASSWORD
+              {{- if .Values.postgres.passwordFromSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.passwordFromSecret.name }}
+                  key: {{ .Values.postgres.passwordFromSecret.key }}
+              {{- else if hasKey $.Values.app.secretEnv "DL_PG_PASSWORD" }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (index $.Values.app.secretEnv "DL_PG_PASSWORD").name }}
+                  key: {{ (index $.Values.app.secretEnv "DL_PG_PASSWORD").key }}
+              {{- else }}
               value: {{ .Values.postgres.env.POSTGRES_PASSWORD | quote }}
+              {{- end }}
+            - name: TZ
+              value: {{ .Values.postgres.env.TZ | quote }}
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
           ports:
@@ -33,3 +48,4 @@ spec:
         - name: postgres-storage
           persistentVolumeClaim:
             claimName: domain-locker-postgres-pvc
+{{- end }}

--- a/helm/templates/postgres-pvc.yaml
+++ b/helm/templates/postgres-pvc.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.postgres.enabled .Values.postgres.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -8,3 +9,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.postgres.persistence.size }}
+{{- end }}

--- a/helm/templates/postgres-service.yaml
+++ b/helm/templates/postgres-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,3 +9,4 @@ spec:
   ports:
     - port: 5432
       targetPort: 5432
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,6 +8,15 @@ app:
     DL_PG_USER: postgres
     DL_PG_PASSWORD: changeme2420
     DL_PG_NAME: domain_locker
+    TZ: UTC
+  secretEnv: {}
+    # To source DL_PG_PASSWORD from a Kubernetes Secret, uncomment and configure below.
+    # This will override the value in app.env for the specified key.
+    # DL_PG_PASSWORD:
+    #   name: my-secret
+    #   key: dl_pg_password
+    # Note: If DL_PG_PASSWORD is specified here, Postgres will also use the same Secret
+    # unless postgres.passwordFromSecret is set.
   ingress:
     enabled: true
     # ingressClassName: "nginx"
@@ -25,12 +34,21 @@ app:
     #   secretName: domain-locker.localhost.com-tls
 
 postgres:
+  enabled: true
   image: postgres:15-alpine
   port: 5432
   env:
     POSTGRES_DB: domain_locker
     POSTGRES_USER: postgres
     POSTGRES_PASSWORD: changeme2420
+    TZ: UTC
+  # Optionally source the POSTGRES_PASSWORD from a Kubernetes Secret.
+  # When set, this will override env.POSTGRES_PASSWORD.
+  # passwordFromSecret:
+  #   name: my-postgres-secret
+  #   key: postgres_password
+  # If passwordFromSecret is not set, this chart will fall back to app.secretEnv.DL_PG_PASSWORD
+  # when present, so app and Postgres share the same secret by default.
   persistence:
     enabled: true
     size: 1Gi


### PR DESCRIPTION
## Summary
Just extended the Helm chart to optional set passwords via secret.
Also add an option to disable postgres if using an external postgres instance.
And added TZ variables.

## Checklist
<!-- Put an X in the checkboxes which apply -->
- [x] I've tested this change
- [x] I've followed the coding style and contribution guidelines
- [x] I've updated documentation (if needed)
- [x] I've confirmed this change is backwards compatible / won't break anything
