### PR TITLE
Add user_info table to schema.sql

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -478,6 +478,19 @@ BEGIN
 END
 $$;
 
+-- User information table
+CREATE TABLE IF NOT EXISTS "public"."user_info" (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    notification_channels jsonb,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    current_plan text,
+    CONSTRAINT user_info_pkey PRIMARY KEY (id),
+    CONSTRAINT user_info_user_id_fkey FOREIGN KEY (user_id) REFERENCES "public"."users" (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_info_user_id ON "public"."user_info" (user_id);
 
 -- Final adjustments and default grants
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA "public" TO "postgres";


### PR DESCRIPTION
Adding missing user_info table to database initialization script.

Only adding this as a suggestion. It's been vibe coded and I have **NOT** run the code - only manually checked by pasting new lines into psql.

## Checklist
<!-- Put an X in the checkboxes which apply -->
- [ ] I've tested this change
- [ ] I've followed the coding style and contribution guidelines
- [ ] I've updated documentation (if needed)
- [ ] I've confirmed this change is backwards compatible / won't break anything
