### PR TITLE
fix: Domain validation regex accept 2-letter TLDs (#39)

### DIFF
--- a/src/app/pages/domains/add/bulk-add/index.page.ts
+++ b/src/app/pages/domains/add/bulk-add/index.page.ts
@@ -200,16 +200,18 @@ export default class BulkAddComponent implements OnInit, OnDestroy {
    */
   parseDomainList(rawInput: string): string[] {
     const lines = rawInput.split(/[\s,]+/);
-    // Example regex: supports e.g. "example.com" or "www.example.com"
     const domainRegex =
-      /^(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,})(?:\/.*)?$/;
+      /^(?:https?:\/\/)?(?:www\.)?([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*)(?:\/.*)?$/i;
 
     const result: string[] = [];
     for (const line of lines) {
       const match = line.trim().match(domainRegex);
       if (match && match[1]) {
         const domain = match[1].toLowerCase();
-        result.push(domain);
+        // Ensure it has at least one dot (is a valid domain)
+        if (domain.includes('.')) {
+          result.push(domain);
+        }
       }
     }
     return result;

--- a/src/app/pages/domains/add/index.page.ts
+++ b/src/app/pages/domains/add/index.page.ts
@@ -92,7 +92,7 @@ export default class AddDomainComponent implements OnInit, OnDestroy {
     this.domainForm = this.fb.group({
       domainName: [this.initialDomain, [
         Validators.required,
-        Validators.pattern(/^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](\.[a-zA-Z]{2,})+$/),
+        Validators.pattern(/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i),
         this.domainExistsValidator()
       ]],
       registrar: ['', Validators.required],

--- a/src/app/pages/domains/add/quick-add/index.page.ts
+++ b/src/app/pages/domains/add/quick-add/index.page.ts
@@ -29,7 +29,7 @@ export default class QuickAddDomain {
   domainForm = this.fb.group({
     domainName: ['', [
       Validators.required,
-      Validators.pattern(/^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](\.[a-zA-Z]{2,})+$/)
+      Validators.pattern(/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i)
     ]],
   });
 


### PR DESCRIPTION
## Summary

## Related
Fixes #39

## Checklist
<!-- Put an X in the checkboxes which apply -->
- [x] I've tested this change
- [x] I've followed the coding style and contribution guidelines
- [x] I've updated documentation (if needed)
- [x] I've confirmed this change is backwards compatible / won't break anything
