### PR TITLE
Refactor loading of Docker secrets from environment variables

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@
 
 # allow setting environment variables with docker secrets 
 # the format is <variable-name>__FILE
-SUFFIX="__FILE"
+SUFFIX="_FILE"
 
 # loop through all environment variables
 for VAR in $(printenv | awk -F= '{print $1}'); do


### PR DESCRIPTION
## Summary
Refactor secret loading to use environment variables with a specific suffix. Added checks for existing environment variables and readable secret files.

The current implementation forces naming secrets after a specific schema which isn't best practice, see multi-service secret sharing here: https://docs.docker.com/compose/how-tos/use-secrets/ and we want to share secrets (e.g. postgres db password). Also: Why restrict secrets to only some vars, let the variables be free and the user choose. The `_FILE` suffix is the de-facto standard.

If you like this, I'll surely be able to update documentation (which isn't including docker secrets right now either).

## Related
#40 & #72

## Checklist
<!-- Put an X in the checkboxes which apply -->
- [x] I've tested this change
- [ ] I've followed the coding style and contribution guidelines
- [ ] I've updated documentation (if needed)
- [x] I've confirmed this change is backwards compatible / won't break anything
