### PR TITLE
fix: prevent ghost changes when SSL data is empty or invalid

### DIFF
--- a/src/server/routes/domain-updater/updateFns/ssl.ts
+++ b/src/server/routes/domain-updater/updateFns/ssl.ts
@@ -74,7 +74,11 @@ export async function updateSSL(
       newVal = normalizeStr(newVal);
     }
 
-    
+    // Skip if both values are empty (no real change)
+    if (!oldVal && !newVal) {
+      continue;
+    }
+
     // Special date comparison, because timezones are stupid
     if (field.type === 'date') {
       const oldDate = new Date(oldVal);
@@ -82,6 +86,12 @@ export async function updateSSL(
 
       const diffInMs = Math.abs(newDate.getTime() - oldDate.getTime());
       const diffInDays = diffInMs / (1000 * 60 * 60 * 24);
+
+      // Skip if new value is invalid/empty (NaN means we couldn't parse the new date)
+      // This prevents ghost changes when SSL fetch fails
+      if (isNaN(diffInDays) && !newVal) {
+        continue;
+      }
 
       if (isNaN(diffInDays) || diffInDays > 1) {
         updateSet.push(`${field.column} = $${updateSet.length + 2}::date`);
@@ -92,6 +102,11 @@ export async function updateSSL(
     }
     
     if (oldVal !== newVal && field.type != 'date') {
+      // Skip recording if new value is empty (likely a fetch failure, not a real change)
+      if (!newVal && oldVal) {
+        continue;
+      }
+
       updateSet.push(`${field.column} = $${updateSet.length + 2}::${field.type}`);
       updateValues.push(field.new ?? null);
 


### PR DESCRIPTION
## Summary

- Fix ghost changes being recorded in `domain_updates` when SSL certificate fetch fails or returns empty data
- Skip recording changes when both old and new values are empty
- Skip recording date changes when new value is invalid/empty (NaN case)
- Skip recording non-date changes when new value is empty but old value exists (fetch failure scenario)

## Problem

When SSL certificate fetching fails (timeout, network error, etc.), the `updateSSL` function was recording "changes" with empty or invalid values. This resulted in confusing entries in the Change History page showing entries like:

```
SSL Valid From changed
25 févr. 2026 -
```

With no meaningful old/new values displayed.

### Root Cause

The date comparison logic at line 86:
```typescript
if (isNaN(diffInDays) || diffInDays > 1) {
```

When SSL fetch fails, `fresh.valid_from` and `fresh.valid_to` are empty strings. `new Date("")` creates an invalid date, making `diffInDays` become `NaN`. The condition `isNaN(diffInDays)` evaluates to `true`, causing a "change" to be recorded even though there's no actual new data.

### Evidence from database

```sql
SELECT * FROM domain_updates WHERE change_type LIKE 'ssl_%';
```

Shows entries with `old_value = ''`, `new_value = ''` or `new_value = '0'`.

## Test plan

- [ ] Verify that legitimate SSL certificate changes are still recorded correctly
- [ ] Verify that SSL fetch failures no longer create ghost entries in domain_updates
- [ ] Check Change History page shows only meaningful changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)