### PR TITLE
Include domain name in webhook notification message

### DIFF
--- a/src/server/routes/domain-updater/lib/notify.ts
+++ b/src/server/routes/domain-updater/lib/notify.ts
@@ -31,6 +31,12 @@ export async function notifyUser(
       return;
     }
 
+    const domainName = await callPgExecutor<any>(
+      pgExec,
+      `SELECT domain_name FROM domains WHERE id = $1`,
+      [domainId]
+    );
+    
     // Insert notification
     await callPgExecutor(
       pgExec,
@@ -43,7 +49,7 @@ export async function notifyUser(
 
     // Send webhook notification
     await sendWebhookNotification(
-      message || `Change detected: ${changeType}`,
+      message || `Change detected in ${domainName}: ${changeType}`,
       'Domain Locker Update',
       [changeType]
     );

--- a/src/server/routes/domain-updater/lib/notify.ts
+++ b/src/server/routes/domain-updater/lib/notify.ts
@@ -31,11 +31,13 @@ export async function notifyUser(
       return;
     }
 
-    const domainName = await callPgExecutor<any>(
+    // Get domain name from domain ID, to include in notification
+    const domainResult = await callPgExecutor<any>(
       pgExec,
       `SELECT domain_name FROM domains WHERE id = $1`,
       [domainId]
     );
+    const domainName = domainResult?.[0]?.domain_name ?? 'unknown domain';
     
     // Insert notification
     await callPgExecutor(


### PR DESCRIPTION
## Summary
Attempt to fix issue #83 by adding the Domain Name to the ntfy notification message.

## Related
#83 

## Checklist
<!-- Put an X in the checkboxes which apply -->
- [ ] I've tested this change
- [x] I've followed the coding style and contribution guidelines
- [ ] I've updated documentation (if needed)
- [ ] I've confirmed this change is backwards compatible / won't break anything

Sorry, the checklist is pretty empty. I originally just reported the issue and then got curious. I don't have a proper environment to test, but the change is so small that it might be close enough. 