### PR TITLE
feat(whois): add Trabis support for .tr TLDs (com.tr, net.tr, gen.tr, etc.)

### DIFF
--- a/src/server/utils/whois.spec.ts
+++ b/src/server/utils/whois.spec.ts
@@ -85,7 +85,9 @@ describe('parseTrabis', () => {
     expect(out!.status).toContain('ok');
     expect(out!.status).toContain('clientTransferProhibited');
     expect(out!.whois.country).toBe('TR');
-    expect(out!.abuse.phone).toBe('90-312-9881106-');
+    expect(out!.whois.name).toBeNull();
+    expect(out!.abuse.email).toBeNull();
+    expect(out!.abuse.phone).toBeNull();
     expect(out!.dnssec).toBeNull();
   });
 

--- a/src/server/utils/whois.spec.ts
+++ b/src/server/utils/whois.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { parseTrabis } from './whois';
+
+/**
+ * Real captured responses from `nc whois.trabis.gov.tr 43` against four .tr
+ * domains. Trabis's format is line-based and stable; these strings let us
+ * lock the parser in without hitting the network from tests.
+ */
+
+const FIXTURE_CANATA = `** Domain Name: canata.com.tr
+Domain Status: Active
+Frozen Status: -
+Transfer Status: The domain is LOCKED to transfer.
+
+** Registrant:
+
+Hidden upon user request
+Hidden upon user request
+Hidden upon user request
+Hidden upon user request
+
+
+** Registrar:
+NIC Handle\t\t: ogv40
+Organization Name\t: ODTÜ GELİŞTİRME VAKFI BİLGİ TEKNOLOJİLERİ SAN. VE TİC. A.Ş.
+Address\t\t\t: Mustafa Kemal Mahallesi Dumlupınar Bulvarı
+\t\t\t  No:280G/1104 Çankaya
+\t\t\t  06800 Ankara Türkiye
+Phone\t\t\t: 90-312-9881106-
+Fax\t\t\t: -
+
+
+** Domain Servers:
+kim.ns.cloudflare.com
+jeff.ns.cloudflare.com
+
+
+** Additional Info:
+Created on..............: 2022-Sep-14.
+Expires on..............: 2026-Sep-13.
+
+
+** Whois Server:
+Last Update Time: 2026-05-28T16:16:33+03:00
+
+`;
+
+const FIXTURE_8092_APEX = `** Domain Name: 8092.tr
+Domain Status: Active
+Frozen Status: -
+Transfer Status: The domain is LOCKED to transfer.
+
+** Registrant:
+
+Hidden upon user request
+Hidden upon user request
+Hidden upon user request
+Hidden upon user request
+
+
+** Registrar:
+NIC Handle\t\t: ogv40
+Organization Name\t: ODTÜ GELİŞTİRME VAKFI BİLGİ TEKNOLOJİLERİ SAN. VE TİC. A.Ş.
+Address\t\t\t: Mustafa Kemal Mahallesi Dumlupınar Bulvarı
+
+** Additional Info:
+Created on..............: 2025-Sep-17.
+Expires on..............: 2026-Sep-16.
+
+Last Update Time: 2026-05-28T16:16:33+03:00
+`;
+
+const FIXTURE_NOT_FOUND = `** No match for "this-domain-does-not-exist.tr".`;
+
+describe('parseTrabis', () => {
+  it('parses a .com.tr response', () => {
+    const out = parseTrabis('canata.com.tr', FIXTURE_CANATA);
+    expect(out).not.toBeNull();
+    expect(out!.domainName).toBe('canata.com.tr');
+    expect(out!.registrar.name).toContain('ODTÜ GELİŞTİRME VAKFI');
+    expect(out!.registrar.id).toBe('ogv40');
+    expect(out!.dates.creation_date).toBe('2022-09-14');
+    expect(out!.dates.expiry_date).toBe('2026-09-13');
+    expect(out!.dates.updated_date).toBe('2026-05-28');
+    expect(out!.status).toContain('ok');
+    expect(out!.status).toContain('clientTransferProhibited');
+    expect(out!.whois.country).toBe('TR');
+    expect(out!.abuse.phone).toBe('90-312-9881106-');
+    expect(out!.dnssec).toBeNull();
+  });
+
+  it('parses a .tr apex response', () => {
+    const out = parseTrabis('8092.tr', FIXTURE_8092_APEX);
+    expect(out).not.toBeNull();
+    expect(out!.domainName).toBe('8092.tr');
+    expect(out!.dates.creation_date).toBe('2025-09-17');
+    expect(out!.dates.expiry_date).toBe('2026-09-16');
+  });
+
+  it('returns null on "no match" responses', () => {
+    expect(parseTrabis('foo.tr', FIXTURE_NOT_FOUND)).toBeNull();
+  });
+
+  it('returns null on empty / suspiciously short responses', () => {
+    expect(parseTrabis('foo.tr', '')).toBeNull();
+    expect(parseTrabis('foo.tr', 'too short')).toBeNull();
+  });
+});

--- a/src/server/utils/whois.ts
+++ b/src/server/utils/whois.ts
@@ -71,7 +71,9 @@ export const getWhoisInfo = async (domain: string): Promise<WhoisResult | null> 
   // native `whois` command resolves to a broken whois.metu.edu.tr CNAME.
   if (/\.tr$/i.test(trimmed)) {
     const trabis = await tryTrabisWhois(trimmed);
-    if (trabis && (trabis.dates.expiry_date || trabis.registrar.name !== 'Unknown')) {
+    // parseTrabis() already returns null for empty/not-found responses, so any
+    // non-null value here is real Trabis data and we should surface it.
+    if (trabis) {
       log.success(`Got WHOIS data via Trabis for ${trimmed}`);
       return trabis;
     }
@@ -513,17 +515,18 @@ const tryWhoisXml = async (domain: string): Promise<WhoisResult | null> => {
  * The response format is stable and easy to parse — see parseTrabis().
  * ──────────────────────────────────────────────────────────────────── */
 
+const TRABIS_MONTHS: Record<string, number> = {
+  jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5,
+  jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11,
+};
+
 // Trabis prints dates as "2022-Sep-14." — translate to ISO yyyy-mm-dd.
 const parseTrabisDate = (raw: string | undefined): string | undefined => {
   if (!raw) return undefined;
   const cleaned = raw.replace(/\.$/, '').trim();
   const m = cleaned.match(/^(\d{4})-([A-Za-z]{3})-(\d{1,2})$/);
   if (m) {
-    const months: Record<string, number> = {
-      jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5,
-      jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11,
-    };
-    const mi = months[m[2].toLowerCase()];
+    const mi = TRABIS_MONTHS[m[2].toLowerCase()];
     if (mi !== undefined) {
       const d = new Date(Date.UTC(+m[1], mi, +m[3]));
       if (!isNaN(d.getTime())) return d.toISOString().split('T')[0];
@@ -566,15 +569,13 @@ export const parseTrabis = (
   const frozen = get(/Frozen Status:\s*(.+?)(?:\r?\n)/);
   if (frozen && frozen !== '-') status.push('serverHold');
 
-  const registrarPhone = get(/Phone\s*:\s*(.+?)(?:\r?\n)/);
-
   return {
     domainName: get(/\*\*\s*Domain Name:\s*(\S+)/) || domain,
     registrar: {
       name: registrarName,
-      id: nicHandle,
-      url: undefined,
-      registryDomainId: undefined,
+      id: nicHandle ?? null,
+      url: null,
+      registryDomainId: null,
     },
     dates: {
       creation_date: parseTrabisDate(get(/Created on\.*:\s*(.+?)(?:\r?\n)/)),
@@ -584,17 +585,20 @@ export const parseTrabis = (
     whois: {
       // Trabis redacts registrant info ("Hidden upon user request"). Country
       // is implicit in the namespace.
-      name: undefined,
-      organization: undefined,
-      street: undefined,
-      city: undefined,
+      name: null,
+      organization: null,
+      street: null,
+      city: null,
       country: 'TR',
-      state: undefined,
-      postal_code: undefined,
+      state: null,
+      postal_code: null,
     },
+    // Trabis doesn't publish a dedicated abuse contact — leaving these empty
+    // rather than spoofing the registrar's general phone number into abuse.phone,
+    // which would be semantically incorrect per WHOIS/RDAP conventions.
     abuse: {
-      email: undefined,
-      phone: registrarPhone && registrarPhone !== '-' ? registrarPhone : undefined,
+      email: null,
+      phone: null,
     },
     status,
     dnssec: null,

--- a/src/server/utils/whois.ts
+++ b/src/server/utils/whois.ts
@@ -1,6 +1,7 @@
 import whois from 'whois-json';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import * as net from 'net';
 import type { Dates, Registrar, Contact, Abuse } from '../../types/common';
 import Logger from './logger';
 
@@ -62,6 +63,19 @@ let rdapBootstrapCache: Record<string, string> | null = null;
 
 export const getWhoisInfo = async (domain: string): Promise<WhoisResult | null> => {
   const trimmed = domain.replace(/^(?:https?:\/\/)?(?:www\.)?/i, '').trim();
+
+  // .tr TLDs (com.tr, net.tr, gen.tr, k12.tr, gov.tr, ...) need a direct
+  // query to whois.trabis.gov.tr — the canonical .tr WHOIS server per IANA.
+  // whois-json doesn't ship .tr in its server map, IANA's RDAP bootstrap
+  // doesn't list .tr (Trabis hasn't published RDAP endpoints), and the
+  // native `whois` command resolves to a broken whois.metu.edu.tr CNAME.
+  if (/\.tr$/i.test(trimmed)) {
+    const trabis = await tryTrabisWhois(trimmed);
+    if (trabis && (trabis.dates.expiry_date || trabis.registrar.name !== 'Unknown')) {
+      log.success(`Got WHOIS data via Trabis for ${trimmed}`);
+      return trabis;
+    }
+  }
 
   const fallback = async (): Promise<WhoisResult | null> => {
     const native = await tryNativeWhois(trimmed);
@@ -480,6 +494,164 @@ const tryWhoisXml = async (domain: string): Promise<WhoisResult | null> => {
     };
   } catch (err) {
     log.warn(`WhoisXML failed for ${domain}: ${(err as Error).message}`);
+    return null;
+  }
+};
+
+/* ──────────────────────────────────────────────────────────────────────
+ * Trabis (.tr) WHOIS support
+ *
+ * The Turkish ccTLD .tr is administered by Trabis (under BTK), which runs
+ * the authoritative WHOIS server at whois.trabis.gov.tr on TCP/43.
+ *
+ * Other tiers in this file all fail for .tr:
+ *   - whois-json:  no .tr in its TLD→server map
+ *   - native whois: resolves to broken whois.metu.edu.tr CNAME (whois.nic.tr
+ *                   has no A record)
+ *   - IANA RDAP bootstrap: doesn't list .tr (Trabis hasn't deployed RDAP)
+ *
+ * The response format is stable and easy to parse — see parseTrabis().
+ * ──────────────────────────────────────────────────────────────────── */
+
+// Trabis prints dates as "2022-Sep-14." — translate to ISO yyyy-mm-dd.
+const parseTrabisDate = (raw: string | undefined): string | undefined => {
+  if (!raw) return undefined;
+  const cleaned = raw.replace(/\.$/, '').trim();
+  const m = cleaned.match(/^(\d{4})-([A-Za-z]{3})-(\d{1,2})$/);
+  if (m) {
+    const months: Record<string, number> = {
+      jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5,
+      jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11,
+    };
+    const mi = months[m[2].toLowerCase()];
+    if (mi !== undefined) {
+      const d = new Date(Date.UTC(+m[1], mi, +m[3]));
+      if (!isNaN(d.getTime())) return d.toISOString().split('T')[0];
+    }
+  }
+  return parseDate(cleaned);
+};
+
+/** Pure parser for Trabis WHOIS text. Exported so it can be unit-tested. */
+export const parseTrabis = (
+  domain: string,
+  text: string,
+): WhoisResult | null => {
+  if (!text || text.length < 50) return null;
+  if (/no match|not found|no entries|domain.*not.*found/i.test(text)) return null;
+
+  const get = (re: RegExp): string | undefined => {
+    const m = text.match(re);
+    return m ? m[1].trim() : undefined;
+  };
+
+  // "** Registrar:" block — capture Organization Name
+  const registrarMatch = text.match(
+    /\*\*\s*Registrar:[\s\S]*?Organization Name\s*:\s*(.+?)(?:\r?\n)/,
+  );
+  const registrarName = registrarMatch ? registrarMatch[1].trim() : 'Unknown';
+
+  // NIC Handle — Trabis's internal registrar id (e.g. "ogv40")
+  const nicHandle = get(/NIC Handle\s*:\s*(\S+)/);
+
+  // Status mapping
+  const statusLine = get(/Domain Status:\s*(.+?)(?:\r?\n)/);
+  const status: string[] = [];
+  if (statusLine) {
+    const s = statusLine.toLowerCase();
+    if (s === 'active') status.push('ok');
+    else if (s !== '-' && s !== '') status.push(statusLine);
+  }
+  if (/LOCKED to transfer/i.test(text)) status.push('clientTransferProhibited');
+  const frozen = get(/Frozen Status:\s*(.+?)(?:\r?\n)/);
+  if (frozen && frozen !== '-') status.push('serverHold');
+
+  const registrarPhone = get(/Phone\s*:\s*(.+?)(?:\r?\n)/);
+
+  return {
+    domainName: get(/\*\*\s*Domain Name:\s*(\S+)/) || domain,
+    registrar: {
+      name: registrarName,
+      id: nicHandle,
+      url: undefined,
+      registryDomainId: undefined,
+    },
+    dates: {
+      creation_date: parseTrabisDate(get(/Created on\.*:\s*(.+?)(?:\r?\n)/)),
+      updated_date: parseDate(get(/Last Update Time:\s*(.+?)(?:\r?\n)/)),
+      expiry_date: parseTrabisDate(get(/Expires on\.*:\s*(.+?)(?:\r?\n)/)),
+    },
+    whois: {
+      // Trabis redacts registrant info ("Hidden upon user request"). Country
+      // is implicit in the namespace.
+      name: undefined,
+      organization: undefined,
+      street: undefined,
+      city: undefined,
+      country: 'TR',
+      state: undefined,
+      postal_code: undefined,
+    },
+    abuse: {
+      email: undefined,
+      phone: registrarPhone && registrarPhone !== '-' ? registrarPhone : undefined,
+    },
+    status,
+    dnssec: null,
+  };
+};
+
+/** Open a TCP/43 socket to Trabis and read the WHOIS response. */
+const fetchTrabisWhois = (domain: string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    const client = net.createConnection({
+      host: 'whois.trabis.gov.tr',
+      port: 43,
+    });
+    const timer = setTimeout(() => {
+      client.destroy();
+      reject(new Error('Trabis WHOIS timeout after 10s'));
+    }, 10_000);
+    client.on('connect', () => client.write(`${domain}\r\n`));
+    client.on('data', (c) => chunks.push(c));
+    client.on('end', () => {
+      clearTimeout(timer);
+      resolve(Buffer.concat(chunks).toString('utf-8'));
+    });
+    client.on('error', (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
+
+/** Top-level Trabis WHOIS lookup. Returns null for non-.tr domains or on error. */
+const tryTrabisWhois = async (
+  domain: string,
+): Promise<WhoisResult | null> => {
+  if (!/\.tr$/i.test(domain)) return null;
+
+  // Skip in serverless environments — raw TCP isn't available.
+  if (
+    process.env['VERCEL'] ||
+    process.env['AWS_LAMBDA_FUNCTION_NAME'] ||
+    process.env['NETLIFY']
+  ) {
+    return null;
+  }
+
+  // Prevent CRLF injection into the WHOIS query line.
+  const sanitised = domain.replace(/[^a-zA-Z0-9.-]/g, '');
+  if (!sanitised || sanitised !== domain) {
+    log.warn(`Invalid domain format for Trabis WHOIS: ${domain}`);
+    return null;
+  }
+
+  try {
+    const raw = await fetchTrabisWhois(sanitised);
+    return parseTrabis(sanitised, raw);
+  } catch (err) {
+    log.warn(`Trabis WHOIS failed for ${domain}: ${(err as Error).message}`);
     return null;
   }
 };


### PR DESCRIPTION
## Why

Domain Locker can't read WHOIS data for `.tr` domains (Turkish ccTLD).
Tested on `canata.com.tr`, `bugracanata.com.tr`, `ituradyo.com.tr`, `8092.tr`
— in all cases the UI shows empty `dates`, `registrar`, and `whois` blocks.

Every existing tier in `src/server/utils/whois.ts` fails for `.tr`:

| Tier | Why it fails for .tr |
|---|---|
| `whois-json` | No `.tr` entry in its TLD→server map; returns empty / errors |
| Native `whois` command | Resolves to broken `whois.metu.edu.tr` CNAME → `whois.nic.tr.` which has no A record |
| IANA RDAP bootstrap (`data.iana.org/rdap/dns.json`) | Doesn't list `.tr` — Trabis hasn't deployed RDAP yet |
| WhoisXML | Only runs if `WHOISXML_API_KEY` is set |

The IANA root db [explicitly names](https://www.iana.org/domains/root/db/tr.html) `whois.trabis.gov.tr` as the canonical WHOIS server for `.tr`. That's what Trabis (the registry under BTK, the Turkish ICT authority) operates today.

## What changed

Adds a new tier `tryTrabisWhois` that:

1. Detects any `*.tr` domain (`.com.tr`, `.net.tr`, `.org.tr`, `.gen.tr`, `.gov.tr`, `.k12.tr`, `.edu.tr`, etc., plus the bare `.tr` namespace)
2. Opens a raw TCP socket to `whois.trabis.gov.tr:43`, sends `<domain>\r\n`, reads the response with a 10s timeout
3. Parses the stable Trabis text format — `** Domain Name`, `** Registrar`, `Created on.....: 2022-Sep-14.`, `Last Update Time:` (ISO), etc.
4. Maps the registry-style status fields to ICANN EPP codes (`Active` → `ok`, `The domain is LOCKED to transfer.` → `clientTransferProhibited`, `Frozen Status` ≠ `-` → `serverHold`)
5. Short-circuits at the top of `getWhoisInfo` for `.tr` to skip the pointless 8s `whois-json` timeout, but **falls through to the existing pipeline** as a courtesy if Trabis happens to fail

The dispatch is one block at the top of `getWhoisInfo` (≈10 lines); all of the parsing logic lives in pure functions below `tryWhoisXml` so it's easy to read in isolation.

## Sample output

Before this PR, `/api/domain-info?domain=canata.com.tr` returned:

```json
{
  "dates": {},
  "registrar": {},
  "whois": {},
  "abuse": {}
}
```

After this PR:

```json
{
  "dates": {
    "creation_date": "2022-09-14",
    "updated_date":  "2026-05-28",
    "expiry_date":   "2026-09-13"
  },
  "registrar": {
    "name": "ODTÜ GELİŞTİRME VAKFI BİLGİ TEKNOLOJİLERİ SAN. VE TİC. A.Ş.",
    "id":   "ogv40"
  },
  "status": ["ok", "clientTransferProhibited"],
  "whois":  { "country": "TR" },
  "abuse":  { "phone": "90-312-9881106-" }
}
```

## Tests

`src/server/utils/whois.spec.ts` — pure parser tests with real captured Trabis responses (no network from tests). Covers:

- `.com.tr` domain (ODTÜ-registered)
- `.tr` apex (bare-namespace registration)
- "No match" response
- Empty / suspiciously short responses

## Security

- The `.tr$` regex is the gate before any network call — non-.tr domains aren't affected.
- Input is sanitised against `[^a-zA-Z0-9.-]` to prevent CRLF injection into the WHOIS query line.
- Same serverless-environment skip as `tryNativeWhois` (`VERCEL`, `AWS_LAMBDA_FUNCTION_NAME`, `NETLIFY`) since raw TCP isn't available there.

## Notes for future maintainers

- **If/when Trabis publishes RDAP**: IANA will add `.tr` to `data.iana.org/rdap/dns.json` and the existing `tryRdapLookup` will Just Work. At that point this Trabis-specific tier could become a fallback rather than the primary `.tr` path. For now (May 2026) it's the only working option.
- **Registrant block is intentionally redacted** by Trabis — every record reads `Hidden upon user request`. This is a Trabis policy, not a parser limitation. We surface `country: 'TR'` since that's implicit in the namespace.
