### PR TITLE
fix: internal loopback url

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,6 +33,10 @@ DL_DEMO_PASS='password123'
 # (optional) For a sitemap, you'll need the base URL
 # DL_BASE_URL='http://localhost:3000'
 
+# (optional) Override the loopback URL used for internal server-to-server calls
+# Defaults to localhost, and only needed if the app doesn't listen there
+# DL_INTERNAL_BASE_URL='http://localhost:3000'
+
 # (optional) To enable Captcha, add your Turnstile key
 # DL_TURNSTILE_KEY=''
 

--- a/src/server/routes/cleanup-monitor-data.ts
+++ b/src/server/routes/cleanup-monitor-data.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler } from 'h3';
-import { getBaseUrl } from '../utils/base-url';
+import { getInternalBaseUrl } from '../utils/base-url';
 
 const RETENTION_DAYS = 7;
 
@@ -22,12 +22,12 @@ async function callPgExecutor<T>(
   return data.data || [];
 }
 
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async () => {
   if (getEnvVar('DL_ENV_TYPE') !== 'selfHosted') {
     return { error: 'Only available in self-hosted mode' };
   }
 
-  const baseUrl = getBaseUrl(event);
+  const baseUrl = getInternalBaseUrl();
   const pgUrl = `${baseUrl}/api/pg-executer`;
   const cutoff = new Date(
     Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000,

--- a/src/server/routes/domain-monitor.ts
+++ b/src/server/routes/domain-monitor.ts
@@ -1,7 +1,7 @@
 import { defineEventHandler } from 'h3';
 import https from 'https';
 import { performance } from 'perf_hooks';
-import { getBaseUrl } from '../utils/base-url';
+import { getInternalBaseUrl } from '../utils/base-url';
 
 const HTTP_TIMEOUT_MS = 10000;
 const MAX_EXECUTION_TIME_MS = 12 * 60 * 1000;
@@ -87,13 +87,13 @@ async function processBatch<T, R>(
   return results;
 }
 
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async () => {
   if (getEnvVar('DL_ENV_TYPE') !== 'selfHosted') {
     return { error: 'Only available in self-hosted mode' };
   }
 
   const startTime = Date.now();
-  const baseUrl = getBaseUrl(event);
+  const baseUrl = getInternalBaseUrl();
   const pgUrl = `${baseUrl}/api/pg-executer`;
 
   const domains = await callPgExecutor<{ id: string; domain_name: string }>(

--- a/src/server/routes/domain-updater/index.ts
+++ b/src/server/routes/domain-updater/index.ts
@@ -3,7 +3,7 @@ import { getEnvVar, withTimeout } from './lib/utils';
 import { callPgExecutor } from './lib/pgExecutor';
 import { fetchDomainInfo } from './lib/fetchInfo';
 import { compareAndUpdateDomain } from './lib/compare';
-import { getBaseUrl } from '../../utils/base-url';
+import { getInternalBaseUrl } from '../../utils/base-url';
 
 const DOMAIN_FETCH_TIMEOUT = 10000; // ms
 const DOMAIN_UPDATE_TIMEOUT = 7000; // ms
@@ -48,12 +48,12 @@ async function runWithConcurrency<T, R>(
   return results;
 }
 
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async () => {
   if (getEnvVar('DL_ENV_TYPE') !== 'selfHosted') {
     return { error: 'Only available in self-hosted mode.' };
   }
 
-  const baseUrl = getBaseUrl(event);
+  const baseUrl = getInternalBaseUrl();
   const pgExecUrl = `${baseUrl}/api/pg-executer`;
   const domainInfoUrl = `${baseUrl}/api/domain-info`;
 

--- a/src/server/routes/expiration-reminders.ts
+++ b/src/server/routes/expiration-reminders.ts
@@ -1,7 +1,7 @@
 import { defineEventHandler } from 'h3';
-import { getBaseUrl } from '../utils/base-url';
+import { getInternalBaseUrl } from '../utils/base-url';
 
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async () => {
   const {
     DL_ENV_TYPE,
     NOTIFY_WEBHOOK_BASE,
@@ -33,8 +33,8 @@ export default defineEventHandler(async (event) => {
     thresholds = defaultThresholds;
   }
 
-  const DL_BASE_URL = getBaseUrl(event);
-  const pgExecUrl = `${DL_BASE_URL}/api/pg-executer`;
+  const baseUrl = getInternalBaseUrl();
+  const pgExecUrl = `${baseUrl}/api/pg-executer`;
   const today = new Date().toISOString().split('T')[0];
 
   const res = await fetch(pgExecUrl, {

--- a/src/server/utils/base-url.ts
+++ b/src/server/utils/base-url.ts
@@ -1,36 +1,17 @@
-import { H3Event, getRequestHeader } from 'h3';
-
 /**
- * Gets the base URL for the current request, with fallback to environment variable
- * Detects the protocol and host from request headers (supports reverse proxies)
+ * Base URL for internal server-to-server calls (pg-executer, domain-info)
+ * Because these need the local loopback and shouldn't go thru reverse proxy
+ * Override with DL_INTERNAL_BASE_URL for non-standard local setups
  *
- * @param event - H3 event object from the request handler
- * @param fallback - Optional fallback URL (defaults to http://localhost:3000)
- * @returns The base URL (e.g., "http://localhost:5173" or "https://domain-locker.com")
+ * @returns The internal base URL (e.g. "http://localhost:3000")
  */
-export function getBaseUrl(event: H3Event, fallback = 'http://localhost:3000'): string {
-  // Check environment variable first
-  const envBaseUrl = process.env['DL_BASE_URL'];
-  if (envBaseUrl) {
-    return envBaseUrl;
+export function getInternalBaseUrl(): string {
+  const override = process.env['DL_INTERNAL_BASE_URL'];
+  if (override) {
+    return override;
   }
 
-  // Detect from request headers (supports reverse proxies)
-  try {
-    const forwardedProto = getRequestHeader(event, 'x-forwarded-proto');
-    const forwardedHost = getRequestHeader(event, 'x-forwarded-host');
-    const host = getRequestHeader(event, 'host');
-    const forwardedSsl = getRequestHeader(event, 'x-forwarded-ssl');
 
-    const protocol = forwardedProto || (forwardedSsl === 'on' ? 'https' : 'http');
-    const hostname = forwardedHost || host;
-
-    if (hostname) {
-      return `${protocol}://${hostname}`;
-    }
-  } catch {
-    // Fall through to fallback
-  }
-
-  return fallback;
+  const port = process.env['NITRO_PORT'] || process.env['PORT'] || '3000';
+  return `http://localhost:${port}`;
 }

--- a/src/server/utils/base-url.ts
+++ b/src/server/utils/base-url.ts
@@ -11,7 +11,6 @@ export function getInternalBaseUrl(): string {
     return override;
   }
 
-
   const port = process.env['NITRO_PORT'] || process.env['PORT'] || '3000';
   return `http://localhost:${port}`;
 }


### PR DESCRIPTION
## Summary
Fixes an issue where the self-hosted domain update job calls the pg-executer using the public URL, so the request was going back out through the reverse proxy and then getting a HTML page instead of JSON.

So the fix was to route internal self-calls to loopback not puublic URL.

Also adds optional env var, `DL_INTERNAL_BASE_URL`, which can be configured if it's running anywhere other than localhost

## Related
Fixes #102

## Checklist
<!-- Put an X in the checkboxes which apply -->
- [X] I've tested this change
- [X] I've followed the coding style and contribution guidelines
- [X] I've updated documentation (if needed)
- [X] I've confirmed this change is backwards compatible / won't break anything
