### PR TITLE
fix: Normalize registrar names

### DIFF
--- a/src/app/pages/assets/registrars/[registrar]/index.page.ts
+++ b/src/app/pages/assets/registrars/[registrar]/index.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 
 import { ActivatedRoute } from '@angular/router';
 import { PrimeNgModule } from '~/app/prime-ng.module';
@@ -47,6 +47,7 @@ export default class RegistrarDomainsPageComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private databaseService = inject(DatabaseService);
   private errorHandler = inject(ErrorHandlerService);
+  private cdr = inject(ChangeDetectorRef);
 
   registrarName = '';
   registrarUrl = '';
@@ -76,6 +77,7 @@ export default class RegistrarDomainsPageComponent implements OnInit {
               this.registrarUrl = 'https://' + this.registrarUrl;
             }
           }
+          this.cdr.markForCheck();
         },
         error: (error) => {
           this.errorHandler.handleError({
@@ -85,6 +87,7 @@ export default class RegistrarDomainsPageComponent implements OnInit {
             location: 'RegistrarIndexPage.loadDomains',
           });
           this.loading = false;
+          this.cdr.markForCheck();
         },
       });
   }

--- a/src/app/pages/assets/registrars/index.page.ts
+++ b/src/app/pages/assets/registrars/index.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 
 import { RouterModule } from '@angular/router';
 import { forkJoin } from 'rxjs';
@@ -17,6 +17,7 @@ import { ErrorHandlerService } from '~/app/services/error-handler.service';
 export default class RegistrarsIndexPageComponent implements OnInit {
   private databaseService = inject(DatabaseService);
   private errorHandler = inject(ErrorHandlerService);
+  private cdr = inject(ChangeDetectorRef);
 
   registrars: (Registrar & { domainCount: number })[] = [];
   loading = true;
@@ -40,6 +41,7 @@ export default class RegistrarsIndexPageComponent implements OnInit {
           }))
           .sort((a, b) => b.domainCount - a.domainCount);
         this.loading = false;
+        this.cdr.markForCheck();
       },
       error: (error) => {
         this.errorHandler.handleError({
@@ -49,6 +51,7 @@ export default class RegistrarsIndexPageComponent implements OnInit {
           location: 'RegistrarsIndexPageComponent.loadRegistrars',
         });
         this.loading = false;
+        this.cdr.markForCheck();
       },
     });
   }

--- a/src/app/services/db-query-services/pg/db-registrars.service.ts
+++ b/src/app/services/db-query-services/pg/db-registrars.service.ts
@@ -1,6 +1,10 @@
-import { catchError, map, Observable } from 'rxjs';
+import { catchError, map, Observable, switchMap } from 'rxjs';
 import { PgApiUtilService } from '~/app/utils/pg-api.util';
-import { normalizeRegistrarName } from '~/app/services/domain-utils.service';
+import {
+  dedupeRegistrars,
+  matchRegistrarRows,
+  mergeRegistrarCounts,
+} from '~/app/services/domain-utils.service';
 import { DbDomain, Registrar } from '~/app/../types/Database';
 
 export class RegistrarQueries {
@@ -10,12 +14,12 @@ export class RegistrarQueries {
     private formatDomainData: (data: Record<string, unknown>) => DbDomain,
   ) {}
 
-  // Get all registrars
+  // Get all registrars, collapsing name variants of the same registrar
   getRegistrars(): Observable<Registrar[]> {
     const query = 'SELECT * FROM registrars';
 
     return this.pgApiUtil.postToPgExecutor<Registrar>(query).pipe(
-      map((response) => response.data),
+      map((response) => dedupeRegistrars(response.data)),
       catchError((error) => this.handleError(error)),
     );
   }
@@ -29,10 +33,7 @@ export class RegistrarQueries {
     const selectResponse = await this.pgApiUtil
       .postToPgExecutor<{ id: string; name: string }>(selectQuery)
       .toPromise();
-    const targetName = normalizeRegistrarName(sanitizedName);
-    const existing = selectResponse?.data.find(
-      (row) => normalizeRegistrarName(row.name) === targetName,
-    );
+    const existing = matchRegistrarRows(selectResponse?.data || [], sanitizedName)[0];
     if (existing) {
       return existing.id;
     }
@@ -46,31 +47,33 @@ export class RegistrarQueries {
     throw new Error('Failed to insert registrar');
   }
 
-  // Get domain counts by registrar
+  // Get domain counts by registrar, merged across name variants
   getDomainCountsByRegistrar(): Observable<Record<string, number>> {
     const query = `
       SELECT r.name AS registrar_name, COUNT(d.id) AS domain_count
-      FROM domains d
-      INNER JOIN registrars r ON d.registrar_id = r.id
+      FROM registrars r
+      -- LEFT JOIN so zero-count variants still feed the canonical name merge
+      LEFT JOIN domains d ON d.registrar_id = r.id
       GROUP BY r.name
     `;
 
     return this.pgApiUtil
-      .postToPgExecutor<{ registrar_name: string; domain_count: number }>(query)
+      .postToPgExecutor<{ registrar_name: string; domain_count: string }>(query)
       .pipe(
         map((response) => {
           const counts: Record<string, number> = {};
           response.data.forEach((item) => {
-            counts[item.registrar_name] = item.domain_count;
+            counts[item.registrar_name] = Number(item.domain_count);
           });
-          return counts;
+          return mergeRegistrarCounts(counts);
         }),
         catchError((error) => this.handleError(error)),
       );
   }
 
-  // Get domains by registrar name
+  // Get domains by registrar name, including variant spellings of the same registrar
   getDomainsByRegistrar(registrarName: string): Observable<DbDomain[]> {
+    const registrarsQuery = 'SELECT id, name FROM registrars';
     const query = `
     SELECT 
       d.id,
@@ -156,16 +159,22 @@ export class RegistrarQueries {
     LEFT JOIN dns_records dr ON d.id = dr.domain_id
     LEFT JOIN domain_tags dt ON d.id = dt.domain_id
     LEFT JOIN tags t ON dt.tag_id = t.id
-    WHERE r.name = $1
-    GROUP BY 
+    WHERE d.registrar_id = ANY($1::uuid[])
+    GROUP BY
       d.id,
       r.name, r.url,
       wi.name, wi.organization, wi.country, wi.street, wi.city, wi.state, wi.postal_code
   `;
 
     return this.pgApiUtil
-      .postToPgExecutor<Record<string, unknown>>(query, [registrarName])
+      .postToPgExecutor<{ id: string; name: string }>(registrarsQuery)
       .pipe(
+        switchMap((registrarsResponse) => {
+          const ids = matchRegistrarRows(registrarsResponse.data, registrarName).map(
+            (row) => row.id,
+          );
+          return this.pgApiUtil.postToPgExecutor<Record<string, unknown>>(query, [ids]);
+        }),
         map((response) => response.data.map(this.formatDomainData)),
         catchError((error) => this.handleError(error)),
       );

--- a/src/app/services/db-query-services/pg/db-registrars.service.ts
+++ b/src/app/services/db-query-services/pg/db-registrars.service.ts
@@ -1,5 +1,6 @@
 import { catchError, map, Observable } from 'rxjs';
 import { PgApiUtilService } from '~/app/utils/pg-api.util';
+import { normalizeRegistrarName } from '~/app/services/domain-utils.service';
 import { DbDomain, Registrar } from '~/app/../types/Database';
 
 export class RegistrarQueries {
@@ -19,17 +20,21 @@ export class RegistrarQueries {
     );
   }
 
-  // Get or insert a registrar by name, recording its url on first insert
+  // Get or insert a registrar, loose-matching existing names to avoid duplicates
   async getOrInsertRegistrarId(registrarName: string, url?: string): Promise<string> {
     const sanitizedName = (registrarName || '').trim().replace(/[/\\?#%]/g, '');
-    const selectQuery = 'SELECT id FROM registrars WHERE name = $1 LIMIT 1';
+    const selectQuery = 'SELECT id, name FROM registrars';
     const insertQuery = 'INSERT INTO registrars (name, url) VALUES ($1, $2) RETURNING id';
 
     const selectResponse = await this.pgApiUtil
-      .postToPgExecutor<{ id: string }>(selectQuery, [sanitizedName])
+      .postToPgExecutor<{ id: string; name: string }>(selectQuery)
       .toPromise();
-    if (selectResponse && selectResponse.data.length > 0) {
-      return selectResponse.data[0].id;
+    const targetName = normalizeRegistrarName(sanitizedName);
+    const existing = selectResponse?.data.find(
+      (row) => normalizeRegistrarName(row.name) === targetName,
+    );
+    if (existing) {
+      return existing.id;
     }
 
     const insertResponse = await this.pgApiUtil

--- a/src/app/services/db-query-services/sb/db-registrars.service.ts
+++ b/src/app/services/db-query-services/sb/db-registrars.service.ts
@@ -1,5 +1,6 @@
 import { SupabaseClient, User } from '@supabase/supabase-js';
 import { catchError, from, map, Observable } from 'rxjs';
+import { normalizeRegistrarName } from '~/app/services/domain-utils.service';
 import { DbDomain, Registrar } from '~/app/../types/Database';
 
 export class RegistrarQueries {
@@ -20,30 +21,32 @@ export class RegistrarQueries {
     );
   }
 
-  // Method to get or insert registrar by name, recording its url on first insert
+  // Get or insert a registrar, loose-matching existing names to avoid duplicates
   async getOrInsertRegistrarId(registrarName: string, url?: string): Promise<string> {
     const sanitizedName = (registrarName || '').trim().replace(/[/\\?#%]/g, '');
-    const { data: existingRegistrar, error: registrarError } = await this.supabase
+    const { data: registrars, error: registrarError } = await this.supabase
       .from('registrars')
+      .select('id, name');
+
+    if (registrarError) throw registrarError;
+
+    const targetName = normalizeRegistrarName(sanitizedName);
+    const existing = (registrars || []).find(
+      (row) => normalizeRegistrarName(row.name) === targetName,
+    );
+    if (existing) {
+      return existing.id;
+    }
+
+    const { data: newRegistrar, error: insertError } = await this.supabase
+      .from('registrars')
+      .insert({ name: sanitizedName, url: url ?? null })
       .select('id')
-      .eq('name', sanitizedName)
       .single();
 
-    if (registrarError && registrarError.code !== 'PGRST116') throw registrarError;
-
-    if (existingRegistrar) {
-      return existingRegistrar.id;
-    } else {
-      const { data: newRegistrar, error: insertError } = await this.supabase
-        .from('registrars')
-        .insert({ name: sanitizedName, url: url ?? null })
-        .select('id')
-        .single();
-
-      if (insertError) throw insertError;
-      if (!newRegistrar) throw new Error('Failed to insert registrar');
-      return newRegistrar.id;
-    }
+    if (insertError) throw insertError;
+    if (!newRegistrar) throw new Error('Failed to insert registrar');
+    return newRegistrar.id;
   }
 
   getDomainCountsByRegistrar(): Observable<Record<string, number>> {

--- a/src/app/services/db-query-services/sb/db-registrars.service.ts
+++ b/src/app/services/db-query-services/sb/db-registrars.service.ts
@@ -1,6 +1,10 @@
 import { SupabaseClient, User } from '@supabase/supabase-js';
 import { catchError, from, map, Observable } from 'rxjs';
-import { normalizeRegistrarName } from '~/app/services/domain-utils.service';
+import {
+  dedupeRegistrars,
+  matchRegistrarRows,
+  mergeRegistrarCounts,
+} from '~/app/services/domain-utils.service';
 import { DbDomain, Registrar } from '~/app/../types/Database';
 
 export class RegistrarQueries {
@@ -11,11 +15,12 @@ export class RegistrarQueries {
     private formatDomainData: (data: Record<string, unknown>) => DbDomain,
   ) {}
 
+  // Get all registrars, collapsing name variants of the same registrar
   getRegistrars(): Observable<Registrar[]> {
     return from(this.supabase.from('registrars').select('*')).pipe(
       map(({ data, error }) => {
         if (error) throw error;
-        return data as Registrar[];
+        return dedupeRegistrars(data as Registrar[]);
       }),
       catchError((error) => this.handleError(error)),
     );
@@ -30,10 +35,7 @@ export class RegistrarQueries {
 
     if (registrarError) throw registrarError;
 
-    const targetName = normalizeRegistrarName(sanitizedName);
-    const existing = (registrars || []).find(
-      (row) => normalizeRegistrarName(row.name) === targetName,
-    );
+    const existing = matchRegistrarRows(registrars || [], sanitizedName)[0];
     if (existing) {
       return existing.id;
     }
@@ -49,31 +51,48 @@ export class RegistrarQueries {
     return newRegistrar.id;
   }
 
+  // Get domain counts by registrar, merged across name variants
   getDomainCountsByRegistrar(): Observable<Record<string, number>> {
-    return from(
-      this.supabase.from('domains').select('registrars(name), id', { count: 'exact' }),
-    ).pipe(
-      map(({ data, error }) => {
-        if (error) throw error;
-        const counts: Record<string, number> = {};
-        const rows = (data || []) as unknown as {
-          registrars?: { name?: string } | null;
-        }[];
-        rows.forEach((item) => {
-          const registrarName = item.registrars?.name;
-          if (registrarName) {
-            counts[registrarName] = (counts[registrarName] || 0) + 1;
-          }
-        });
-        return counts;
-      }),
-      catchError((error) => this.handleError(error)),
-    );
+    const fetchCounts = async (): Promise<Record<string, number>> => {
+      const [namesResult, domainsResult] = await Promise.all([
+        this.supabase.from('registrars').select('name'),
+        this.supabase.from('domains').select('registrars(name)'),
+      ]);
+      if (namesResult.error) throw namesResult.error;
+      if (domainsResult.error) throw domainsResult.error;
+
+      const counts: Record<string, number> = {};
+      const rows = (domainsResult.data || []) as unknown as {
+        registrars?: { name?: string } | null;
+      }[];
+      rows.forEach((item) => {
+        const registrarName = item.registrars?.name;
+        if (registrarName) {
+          counts[registrarName] = (counts[registrarName] || 0) + 1;
+        }
+      });
+
+      const allNames = (namesResult.data || []).map((row) => row.name);
+      return mergeRegistrarCounts(counts, allNames);
+    };
+
+    return from(fetchCounts()).pipe(catchError((error) => this.handleError(error)));
   }
 
+  // Get domains for a registrar, including variant spellings of its name
   getDomainsByRegistrar(registrarName: string): Observable<DbDomain[]> {
-    return from(
-      this.supabase
+    const fetchDomains = async () => {
+      const { data: registrars, error: registrarsError } = await this.supabase
+        .from('registrars')
+        .select('id, name');
+      if (registrarsError) throw registrarsError;
+
+      const ids = matchRegistrarRows(registrars || [], registrarName).map(
+        (row) => row.id,
+      );
+      if (!ids.length) return { data: [], error: null };
+
+      return this.supabase
         .from('domains')
         .select(
           `
@@ -93,8 +112,10 @@ export class RegistrarQueries {
         )
       `,
         )
-        .eq('registrars.name', registrarName),
-    ).pipe(
+        .in('registrar_id', ids);
+    };
+
+    return from(fetchDomains()).pipe(
       map(({ data, error }) => {
         if (error) throw error;
         return (data as unknown as Record<string, unknown>[]).map((domain) =>

--- a/src/app/services/domain-utils.service.ts
+++ b/src/app/services/domain-utils.service.ts
@@ -12,6 +12,61 @@ export function normalizeRegistrarName(input: string | null | undefined): string
     .replace(/[\s,.-]+/g, '');
 }
 
+// Pick a stable display name per group of variants (longest wins, then alphabetical)
+function canonicalRegistrarNames(names: string[]): Map<string, string> {
+  const canonical = new Map<string, string>();
+  for (const name of names) {
+    const key = normalizeRegistrarName(name);
+    const current = canonical.get(key);
+    if (
+      !current ||
+      name.length > current.length ||
+      (name.length === current.length && name < current)
+    ) {
+      canonical.set(key, name);
+    }
+  }
+  return canonical;
+}
+
+// Rows whose names loose-match the given registrar name
+export function matchRegistrarRows<T extends { name: string }>(
+  rows: T[],
+  target: string,
+): T[] {
+  const targetName = normalizeRegistrarName(target);
+  return rows.filter((row) => normalizeRegistrarName(row.name) === targetName);
+}
+
+// Collapse name variants to one row per registrar, backfilling url from variants
+export function dedupeRegistrars<T extends { name: string; url?: string | null }>(
+  rows: T[],
+): T[] {
+  const canonical = canonicalRegistrarNames(rows.map((row) => row.name));
+  return rows
+    .filter((row) => canonical.get(normalizeRegistrarName(row.name)) === row.name)
+    .map((kept) => {
+      if (kept.url) return kept;
+      const withUrl = matchRegistrarRows(rows, kept.name).find((row) => row.url);
+      return withUrl ? { ...kept, url: withUrl.url } : kept;
+    });
+}
+
+// Sum domain counts across name variants, keyed by the canonical name
+export function mergeRegistrarCounts(
+  counts: Record<string, number>,
+  allNames: string[] = Object.keys(counts),
+): Record<string, number> {
+  const canonical = canonicalRegistrarNames(allNames);
+  const merged: Record<string, number> = {};
+  for (const [name, count] of Object.entries(counts)) {
+    if (!count) continue;
+    const display = canonical.get(normalizeRegistrarName(name)) || name;
+    merged[display] = (merged[display] || 0) + count;
+  }
+  return merged;
+}
+
 @Injectable({
   providedIn: 'root',
 })

--- a/src/app/services/domain-utils.service.ts
+++ b/src/app/services/domain-utils.service.ts
@@ -3,6 +3,15 @@ import { DbDomain } from '~/app/../types/Database';
 import { Injectable } from '@angular/core';
 import { makeEppArrayFromLabels } from '~/app/constants/security-categories';
 
+// Loose-match registrar names, ignoring case, punctuation and any trailing [Tag] suffix
+export function normalizeRegistrarName(input: string | null | undefined): string {
+  return (input || '')
+    .replace(/\s*\[[^\]]*\]\s*$/, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s,.-]+/g, '');
+}
+
 @Injectable({
   providedIn: 'root',
 })

--- a/src/server/routes/domain-updater/lib/utils.ts
+++ b/src/server/routes/domain-updater/lib/utils.ts
@@ -14,6 +14,15 @@ export function removeUrlChars(input: string | null | undefined): string {
   return (input || '').trim().replace(/[/\\?#%]/g, '');
 }
 
+// Loose-match registrar names, ignoring case, punctuation and any trailing [Tag] suffix
+export function normalizeRegistrarName(input: string | null | undefined): string {
+  return (input || '')
+    .replace(/\s*\[[^\]]*\]\s*$/, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s,.-]+/g, '');
+}
+
 export function normalizeDate(input: string | null | undefined): string {
   if (!input) return '';
   const date = new Date(input);

--- a/src/server/routes/domain-updater/updateFns/registrar.ts
+++ b/src/server/routes/domain-updater/updateFns/registrar.ts
@@ -1,6 +1,6 @@
 import { callPgExecutor } from '../lib/pgExecutor';
 import { recordDomainUpdate } from '../lib/recordUpdate';
-import { normalizeStr, removeUrlChars } from '../lib/utils';
+import { normalizeRegistrarName, normalizeStr, removeUrlChars } from '../lib/utils';
 import type { DomainRow } from '../index';
 import type { FreshDomainInfo } from '../lib/fetchInfo';
 
@@ -11,6 +11,17 @@ async function upsertRegistrar(
   userId: string,
 ): Promise<string> {
   const sanitizedName = removeUrlChars(name);
+  const registrars = await callPgExecutor<{ id: string; name: string }>(
+    pgExec,
+    `SELECT id, name FROM registrars WHERE user_id = $1`,
+    [userId],
+  );
+  const targetName = normalizeRegistrarName(sanitizedName);
+  const existing = registrars.find(
+    (row) => normalizeRegistrarName(row.name) === targetName,
+  );
+  if (existing) return existing.id;
+
   const res = await callPgExecutor<{ id: string }>(
     pgExec,
     `
@@ -37,7 +48,9 @@ export async function updateRegistrar(
 
   const userId = domainRow.user_id || 'a0000000-aaaa-42a0-a0a0-00a000000a69';
 
-  if (!newName || oldName === newName) return;
+  if (!newName || normalizeRegistrarName(oldName) === normalizeRegistrarName(newName)) {
+    return;
+  }
 
   const registrarId = await upsertRegistrar(
     pgExec,


### PR DESCRIPTION
## Summary
Different TLDs RDAP servers tend to return the same registrar with different casing or puncuation
which can lead to the user seeing the same registrar multiple times, just spelt different
This PR fixes this, by normalizing registrar name whenever the domain is updated

## Related
Fixes #112

## Checklist
- [X] I've tested this change
- [X] I've followed the coding style and contribution guidelines
- [X] I've updated documentation (if needed)
- [X] I've confirmed this change is backwards compatible / won't break anything
