### PR TITLE
fix: specify database in Postgres healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - domain_locker_network
 
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DL_PG_USER:-postgres}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DL_PG_USER:-postgres} -d ${DL_PG_NAME:-domain_locker}"]
       interval: 5s
       timeout: 3s
       retries: 10


### PR DESCRIPTION
## Summary
The Compose Postgres healthcheck invokes `pg_isready` with a user but no database name. PostgreSQL then defaults the database name to the username, resulting in a `database "<user>" does not exist` log entry every five seconds when those values differ.

## Related
N/A

## Checklist
<!-- Put an X in the checkboxes which apply -->
- [X] I've tested this change
- [X] I've followed the coding style and contribution guidelines
- [X] I've updated documentation (if needed)
- [X] I've confirmed this change is backwards compatible / won't break anything
