### PR TITLE
fix: Configurable whois concurrency and request delay

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -60,6 +60,11 @@ DL_DEMO_PASS='password123'
 # (optional, self-hosted) Number of concurrent domain checks (default: 10)
 # DL_MONITOR_CONCURRENCY='10'
 #
+# (optional, self-hosted) Pace the domain updater, for registries which rate limit
+# whois queries (such as .it and .eu). Delay is the gap between requests, in ms
+# DL_WHOIS_CONCURRENCY='5'
+# DL_WHOIS_DELAY_MS='0'
+#
 # (optional, self-hosted) Set to `true` to disable SSRF protection for internal domains
 # DL_DISABLE_SSRF_PROTECTION='true'
 #

--- a/src/content/docs/developing/environmental-variables.md
+++ b/src/content/docs/developing/environmental-variables.md
@@ -145,6 +145,8 @@ This value is used by **FeatureService** to dynamically enable or disable featur
 | `DL_DOMAIN_INFO_API` | API endpoint for domain info (`/api/domain-info`). | ✅ |
 | `DL_DOMAIN_SUBS_API` | API endpoint for domain subscription data. | ✅ |
 | `DL_WHO_DAT_URL` | Base URL of a [who-dat](https://github.com/lissy93/who-dat) instance, used as the first whois fallback (defaults to the public instance). | ❌ |
+| `DL_WHOIS_CONCURRENCY` | Number of domains the updater processes at once (default: `5`). | ❌ |
+| `DL_WHOIS_DELAY_MS` | Milliseconds to wait between updater requests, for registries which rate limit whois (default: `0`). | ❌ |
 | `DL_STRIPE_CHECKOUT_URL` | Stripe checkout session creation URL. | ❌ |
 | `DL_STRIPE_CANCEL_URL` | Stripe subscription cancellation URL. | ❌ |
 

--- a/src/server/routes/domain-updater/index.ts
+++ b/src/server/routes/domain-updater/index.ts
@@ -8,6 +8,18 @@ import { getInternalBaseUrl } from '../../utils/base-url';
 const DOMAIN_FETCH_TIMEOUT = 10000; // ms
 const DOMAIN_UPDATE_TIMEOUT = 7000; // ms
 const CONCURRENCY_LIMIT = 5;
+const REQUEST_DELAY_MS = 0;
+
+// Registries such as NIC.it and EURid throttle a source IP once a run sends a
+// burst of WHOIS queries, so both the worker count and the gap between
+// requests can be tuned per deployment.
+function readEnvInt(name: string, fallback: number, min: number): number {
+  const value = Number(getEnvVar(name, String(fallback)));
+  return Number.isFinite(value) && value >= min ? Math.floor(value) : fallback;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 export interface DomainRow {
   id: string;
@@ -25,7 +37,8 @@ type WorkerResult<R> = R | { domain: string; error: string };
 async function runWithConcurrency<T, R>(
   items: T[],
   workerFn: (item: T) => Promise<R>,
-  limit = CONCURRENCY_LIMIT,
+  limit = readEnvInt('DL_WHOIS_CONCURRENCY', CONCURRENCY_LIMIT, 1),
+  delayMs = readEnvInt('DL_WHOIS_DELAY_MS', REQUEST_DELAY_MS, 0),
 ): Promise<WorkerResult<R>[]> {
   const results: WorkerResult<R>[] = [];
   const queue = [...items];
@@ -42,6 +55,7 @@ async function runWithConcurrency<T, R>(
         const name = (item as { domain_name?: string })?.domain_name ?? 'unknown';
         results.push({ domain: name, error: msg });
       }
+      if (delayMs > 0 && queue.length) await sleep(delayMs);
     }
   });
 


### PR DESCRIPTION
The domain updater ran a fixed five workers with no gap between requests. Both values are now read from the environment, and the defaults keep the current behaviour.

DL_WHOIS_CONCURRENCY: number of workers, default 5.
DL_WHOIS_DELAY_MS: gap between requests in milliseconds, default 0.

Documented in .env.sample and docs/developing/environmental-variables.md.

Closes #120

The same failure is reported in #93 and #87.
